### PR TITLE
changes for bug fixes.

### DIFF
--- a/fidelis-edr/info.json
+++ b/fidelis-edr/info.json
@@ -143,18 +143,19 @@
           "type": "integer",
           "name": "take",
           "description": "Specify the maximum number of alerts that you want this operation to return in the response.By default, this is set to \"all\" alerts.",
-          "tooltip": "Limit the number of alerts to return in response",
+          "tooltip": "Limit the number of alerts to return in response. default is set to 1000",
           "required": false,
           "editable": true,
-          "visible": true
+          "visible": true,
+          "value": 1000
         },
         {
           "title": "Sort Alerts",
           "type": "text",
           "name": "sort",
-          "placeholder": "e.g CreatedDate Descending",
-          "description": "Specify the property name and order (Ascending or Descending) to sort the results retrieved by this operation, before applying take and skip. By default, this is set to \"CreatedDate Descending\". You can specify the name of any property of the alert object.",
-          "tooltip": "Sorts the result before applying take and skip. Defaults to \"CreatedDate Descending\". Can be any property name of the alert object.",
+          "placeholder": "e.g id Descending",
+          "description": "Specify the property name and order (Ascending or Descending) to sort the results retrieved by this operation, before applying take and skip. By default, this is set to \"id Descending\". You can specify the name of any property of the alert object.",
+          "tooltip": "Sorts the result before applying take and skip. Defaults to \"id Descending\". Can be any property name of the alert object.",
           "required": false,
           "editable": true,
           "visible": true

--- a/fidelis-edr/operations.py
+++ b/fidelis-edr/operations.py
@@ -112,6 +112,8 @@ def get_alerts(config, params):
     fa = Fidelis(config)
     endpoint = 'alerts/getalertsV2'
     params = get_params(params)
+    if not params.get('take'):
+        params['take'] = 1000
     return fa.make_api_call(endpoint=endpoint, params=params)
 
 


### PR DESCRIPTION
PR Title: Bug fix

BUG: get Alerts: No alerts are fetched even when no filter is applied

Descritpion: The API used for the get alerts action has all optional parameters, but executing without any parameter returns an empty response. so I added a default value for the 'take' parameter to get the data.

Impact: Get alerts action

UTC: 
- Install the connector using .tgz
- Verified Get alerts action with no input params